### PR TITLE
Clear search text upon opening to browser

### DIFF
--- a/app/src/main/java/de/tobiasbielefeld/searchbar/ui/MainActivity.java
+++ b/app/src/main/java/de/tobiasbielefeld/searchbar/ui/MainActivity.java
@@ -164,6 +164,7 @@ public class MainActivity extends CustomAppCompatActivity implements TextWatcher
 
             try {
                 startActivity(browserIntent);                                                       //try to start the browser, if there is one installed
+                setSearchText("");
             } catch (ActivityNotFoundException e) {
                 e.printStackTrace();
                 showToast(getString(R.string.unsupported_search_string));


### PR DESCRIPTION
So you don't need to clear your previous search every time you open the widget.