### PR TITLE
Fix defaulting to startpage

### DIFF
--- a/app/src/main/java/de/tobiasbielefeld/searchbar/SharedData.java
+++ b/app/src/main/java/de/tobiasbielefeld/searchbar/SharedData.java
@@ -67,7 +67,8 @@ public class SharedData {
             PREF_STATUS_BAR = res.getString(R.string.pref_key_hide_status_bar);
             PREF_LANGUAGE = res.getString(R.string.pref_key_language);
 
-            DEFAULT_SEARCH_URL = res.getStringArray(R.array.search_engine_uris)[6];
+            int n = res.getInteger(R.integer.default_search_engine);
+            DEFAULT_SEARCH_URL = res.getStringArray(R.array.search_engine_uris)[n];
             DEFAULT_ORIENTATION = res.getStringArray(R.array.pref_orientation_values)[0];
             DEFAULT_STATUS_BAR = res.getBoolean(R.bool.default_status_bar);
         }

--- a/app/src/main/java/de/tobiasbielefeld/searchbar/SharedData.java
+++ b/app/src/main/java/de/tobiasbielefeld/searchbar/SharedData.java
@@ -67,7 +67,7 @@ public class SharedData {
             PREF_STATUS_BAR = res.getString(R.string.pref_key_hide_status_bar);
             PREF_LANGUAGE = res.getString(R.string.pref_key_language);
 
-            DEFAULT_SEARCH_URL = res.getStringArray(R.array.search_engine_uris)[5];
+            DEFAULT_SEARCH_URL = res.getStringArray(R.array.search_engine_uris)[6];
             DEFAULT_ORIENTATION = res.getStringArray(R.array.pref_orientation_values)[0];
             DEFAULT_STATUS_BAR = res.getBoolean(R.bool.default_status_bar);
         }

--- a/app/src/main/java/de/tobiasbielefeld/searchbar/dialogs/PreferenceDialogSearchEngine.java
+++ b/app/src/main/java/de/tobiasbielefeld/searchbar/dialogs/PreferenceDialogSearchEngine.java
@@ -60,7 +60,8 @@ public class PreferenceDialogSearchEngine extends ListPreference{
      * If a custom search engine was selected, show its url, else show the title of the engine
      */
     private void updateSummary(){
-        String selectedValue = getPersistedString(getContext().getString(R.string.default_search_engine));
+        int d = getContext().getResources().getInteger(R.integer.default_search_engine);
+        String selectedValue = getPersistedString(d + "");
         int index = findIndexOfValue(selectedValue);
 
         if (index == 0){    //custom search engine

--- a/app/src/main/java/de/tobiasbielefeld/searchbar/ui/MainActivity.java
+++ b/app/src/main/java/de/tobiasbielefeld/searchbar/ui/MainActivity.java
@@ -164,6 +164,7 @@ public class MainActivity extends CustomAppCompatActivity implements TextWatcher
 
             try {
                 startActivity(browserIntent);                                                       //try to start the browser, if there is one installed
+                setSearchText("");
             } catch (ActivityNotFoundException e) {
                 e.printStackTrace();
                 showToast(getString(R.string.unsupported_search_string));

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="max_number_records">20</integer>
-
-    <string name="default_search_engine" translatable="false">6</string>
+    <integer name="default_search_engine">6</integer>
 </resources>

--- a/app/src/main/res/xml/pref_search.xml
+++ b/app/src/main/res/xml/pref_search.xml
@@ -4,7 +4,7 @@
         android:key="@string/pref_key_search_engine"
         android:title="@string/settings_search_engine_title"
         android:negativeButtonText="@string/cancel"
-        android:defaultValue="@string/default_search_engine"
+        android:defaultValue="@integer/default_search_engine"
         android:entries="@array/pref_search_engine_titles"
         android:entryValues="@array/pref_search_engine_values"/>
 


### PR DESCRIPTION
This fixes a bug where the actual default search engine was startpage until you opened preferences for the first time.

I've arranged this pull request so that if you merge https://github.com/TobiasBielefeld/Simple-Search/pull/1 first, both should be fast-forwards.