### PR TITLE
Modified activity_main.xml and colors.xml

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -100,7 +100,7 @@
                         android:inputType="text"
                         android:singleLine="true"
                         android:textColor="@color/toolbarText"
-                        android:textColorHint="@color/toolbarHint" />
+                        android:textColorHint="@color/toolbarHint_new" />
 
                     <ImageView
                         android:id="@+id/imageButtonClear"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -6,6 +6,7 @@
     <color name="blueBackground">#3f83ff</color>
     <color name="mainBackground">#FFFAFAFA</color>
     <color name="toolbarHint">#999999</color>
+    <color name="toolbarHint_new">#757575</color>
     <color name="toolbarText">#454545</color>
     <color name="dialog_highlight">#39000000</color>
     <color name="loading_background">#50000000</color>


### PR DESCRIPTION
Hello,
I just discovered a color-related issue: the hint text has insufficient color contrast, making it hard to read and potentially affecting accessibility. Therefore, the color should be appropriately darkened.

before:
![31b](https://github.com/user-attachments/assets/ec8d6fe6-c12a-4ef2-938c-99d424915506)

after:
![31a](https://github.com/user-attachments/assets/9f05a6d8-bf7c-47d3-9587-8f57106b2e65)
